### PR TITLE
feat: add appsync lambda handler

### DIFF
--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -30,3 +30,7 @@ export const EventBridgeEnv = D.intersect(NodeEnv)(
     AWS_EVENTBRIDGE_REGION: D.string,
   })
 );
+
+export const AppSyncLambdaError = D.struct({
+  errorMessage: D.string
+});


### PR DESCRIPTION
It would be nice to use a decoder to map http and appsync lambda's response, I would keep it as a todo when we will make cleaner these handlers