### PR TITLE
Fix logger

### DIFF
--- a/src/Logger/LogStore.ts
+++ b/src/Logger/LogStore.ts
@@ -1,5 +1,3 @@
-import * as A from "fp-ts/lib/Array";
-import { pipe } from "fp-ts/lib/function";
 import { Log, Logger } from "./Logger";
 
 export class LogStore {
@@ -11,10 +9,7 @@ export class LogStore {
 
   private printStore = () => {
     this.logs.forEach((l) => {
-      const message = l[0];
-      const logObject = l.length === 2 ? l[1] : pipe(l, A.dropLeft(1));
-
-      this.logger.debug(logObject, message);
+      this.logger.debug(l[0], l[1]);
     });
   };
 
@@ -22,7 +17,7 @@ export class LogStore {
     private logger: Logger,
     public readonly capacity = Infinity,
     private areLogEnabled = () => process.env.FRAMEWORK_LOGS === "true"
-  ) {}
+  ) { }
 
   public getCapacity = () => {
     return `${this.logs.length}/${this.capacity}`;
@@ -37,7 +32,7 @@ export class LogStore {
     }
 
     if (this.areLogEnabled()) {
-      this.logger.debug(...l);
+      this.logger.debug(l[0], l[1]);
     }
 
     this.logs.push(l);

--- a/src/Logger/Logger.ts
+++ b/src/Logger/Logger.ts
@@ -1,6 +1,6 @@
 import pino from "pino";
 
-export type Log = [s: string, ...args: any[]];
+export type Log = [message: string, mergingObject?: Record<string, unknown>];
 
 interface LoggerOptions {
   name: string;
@@ -15,5 +15,11 @@ export interface Logger {
 export const getPinoLogger = ({ name }: LoggerOptions): Logger => {
   const logger = pino({ name, level: "debug" });
 
-  return logger;
+  return {
+    debug: (...args: Log) => {
+      logger.debug(args[1], args[0]);
+    },
+    warn: (msg: string) => logger.warn(msg),
+    info: (msg: string) => logger.info(msg),
+  }
 };

--- a/src/__test__/LogStore.test.ts
+++ b/src/__test__/LogStore.test.ts
@@ -43,7 +43,7 @@ describe.only("LogStore", () => {
     );
   });
 
-  it.only("when resetting the store and logs are not enabled, it prints the log", async () => {
+  it("when resetting the store and logs are not enabled, it prints the log", async () => {
     const logger = getPinoLogger({ name: "TEST" });
     const pinoDebugSpy = jest.spyOn(logger, "debug");
 

--- a/src/__test__/LogStore.test.ts
+++ b/src/__test__/LogStore.test.ts
@@ -43,7 +43,7 @@ describe.only("LogStore", () => {
     );
   });
 
-  it("when resetting the store and logs are not enabled, it prints the log", async () => {
+  it.only("when resetting the store and logs are not enabled, it prints the log", async () => {
     const logger = getPinoLogger({ name: "TEST" });
     const pinoDebugSpy = jest.spyOn(logger, "debug");
 
@@ -55,13 +55,13 @@ describe.only("LogStore", () => {
 
     expect(pinoDebugSpy.mock.calls).toEqual([
       [
+        "foo baz bar",
         {
           baz: ["bar"],
           foo: 1,
         },
-        "foo baz bar",
       ],
-      [[], "foobazbar"],
+      ["foobazbar", undefined],
     ]);
   });
 
@@ -90,5 +90,15 @@ describe.only("LogStore", () => {
     logStore.reset();
 
     expect(logStore.getCapacity()).toBe("0/3");
+  });
+
+  it("pass message and merging object to logger.debug when logs are enabled", async () => {
+    const logger = getPinoLogger({ name: "TEST" });
+    const pinoDebugSpy = jest.spyOn(logger, "debug");
+    const logStore = new LogStore(logger, Infinity, () => true);
+
+    logStore.appendLog(["LogMessageName", { foo: "bar" }]);
+
+    expect(pinoDebugSpy).toHaveBeenCalledWith("LogMessageName", { foo: "bar" });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,236 +79,236 @@ export const _eventLambda =
     wrapperFunc: WrapHandler<EventBridgeEvent<string, O>, R | void>,
     envRuntime = process.env
   ) =>
-  ({ eventDetailSchema, envSchema }: EventLambdaConfig<A, K>) =>
-  (
-    handler: ({
-      event,
-      eventMeta,
-      env,
-    }: {
-      event: A;
-      eventMeta: EventMeta;
-      env: Record<K, string> | undefined;
-      logStore: LogStore;
-    }) => taskEither.TaskEither<unknown, R>
-  ) => {
-    return wrapperFunc((event: EventBridgeEvent<string, O>) => {
-      const logStore = new LogStore(
-        getPinoLogger({ name: "framework-node" }),
-        500
-      );
+    ({ eventDetailSchema, envSchema }: EventLambdaConfig<A, K>) =>
+      (
+        handler: ({
+          event,
+          eventMeta,
+          env,
+        }: {
+          event: A;
+          eventMeta: EventMeta;
+          env: Record<K, string> | undefined;
+          logStore: LogStore;
+        }) => taskEither.TaskEither<unknown, R>
+      ) => {
+        return wrapperFunc((event: EventBridgeEvent<string, O>) => {
+          const logStore = new LogStore(
+            getPinoLogger({ name: "framework-node" }),
+            500
+          );
 
-      logStore.appendLog(["parsing event: ", event.detail]);
+          logStore.appendLog(["parsing event: ", { event: event.detail }]);
 
-      const eventMeta = {
-        ...event,
-        time: decodeOrThrow(DateFromISOString, event.time),
-        detail: undefined,
-      };
+          const eventMeta = {
+            ...event,
+            time: decodeOrThrow(DateFromISOString, event.time),
+            detail: undefined,
+          };
 
-      const parsedEvent = pipe(
-        parse(eventDetailSchema, event.detail),
-        taskEither.fromEither,
-        taskEither.map((v) => {
-          logStore.appendLog(["parsed event successfully: ", v]);
-          return v;
-        }),
-        taskEither.mapLeft((e) => `Incorrect Event Detail: ${draw(e)}`)
-      );
+          const parsedEvent = pipe(
+            parse(eventDetailSchema, event.detail),
+            taskEither.fromEither,
+            taskEither.map((v) => {
+              logStore.appendLog(["parsed event successfully: ", { event: v }]);
+              return v;
+            }),
+            taskEither.mapLeft((e) => `Incorrect Event Detail: ${draw(e)}`)
+          );
 
-      // we build the task making sure to have a readable error if the decoding fails
-      const handlerTask = pipe(
-        taskEither.Do,
-        taskEither.bind("event", () => parsedEvent),
-        taskEither.bind("eventMeta", () => taskEither.of(eventMeta)),
-        taskEither.bind("env", () =>
-          envSchema
-            ? parseRecordValues(envSchema, envRuntime, logStore)
-            : taskEither.of(undefined)
-        ),
-        taskEither.chain((i) => handler({ ...i, logStore }))
-      );
+          // we build the task making sure to have a readable error if the decoding fails
+          const handlerTask = pipe(
+            taskEither.Do,
+            taskEither.bind("event", () => parsedEvent),
+            taskEither.bind("eventMeta", () => taskEither.of(eventMeta)),
+            taskEither.bind("env", () =>
+              envSchema
+                ? parseRecordValues(envSchema, envRuntime, logStore)
+                : taskEither.of(undefined)
+            ),
+            taskEither.chain((i) => handler({ ...i, logStore }))
+          );
 
-      // we throw in case of error
-      return handlerTask()
-        .then((result) => {
-          if (either.isLeft(result)) {
-            if (string.isString(result.left)) {
-              throw `[node-framework] ${result.left}`;
-            } else {
-              logStore.appendLog(["unknown error...: ", result.left]);
-              throw new Error("[node-framework] handler unknown error");
-            }
-          }
+          // we throw in case of error
+          return handlerTask()
+            .then((result) => {
+              if (either.isLeft(result)) {
+                if (string.isString(result.left)) {
+                  throw `[node-framework] ${result.left}`;
+                } else {
+                  logStore.appendLog(["unknown error...: ", { error: result.left }]);
+                  throw new Error("[node-framework] handler unknown error");
+                }
+              }
 
-          logStore.appendLog(["handler succeded with payload: ", result.right]);
-          logStore.reset();
+              logStore.appendLog(["handler succeded with payload: ", { success: result.right }]);
+              logStore.reset();
 
-          return result.right;
-        })
-        .catch((e) => {
-          logStore.appendLog(["handler failed!: ", e]);
-          logStore.reset();
-          throw e;
+              return result.right;
+            })
+            .catch((e) => {
+              logStore.appendLog(["handler failed!: ", e]);
+              logStore.reset();
+              throw e;
+            });
         });
-    });
-  };
+      };
 
 export const _httpLambda =
   <A, R, K extends string = never>(
     wrapperFunc: WrapHandler<APIGatewayProxyEvent, R | void>,
     envRuntime = process.env
   ) =>
-  (config: HttpLambdaConfig<A, K>) =>
-  (
-    handler: ({
-      body,
-      headers,
-      env,
-    }: {
-      body: A;
-      headers: Record<K, string> | undefined;
-      env: Record<K, string> | undefined;
-      logStore: LogStore;
-    }) => taskEither.TaskEither<unknown, R>
-  ) => {
-    return wrapperFunc((event: APIGatewayProxyEvent) => {
-      const logStore = new LogStore(
-        getPinoLogger({ name: "framework-node" }),
-        500
-      );
-      logStore.appendLog(["parsing body: ", config.body]);
+    (config: HttpLambdaConfig<A, K>) =>
+      (
+        handler: ({
+          body,
+          headers,
+          env,
+        }: {
+          body: A;
+          headers: Record<K, string> | undefined;
+          env: Record<K, string> | undefined;
+          logStore: LogStore;
+        }) => taskEither.TaskEither<unknown, R>
+      ) => {
+        return wrapperFunc((event: APIGatewayProxyEvent) => {
+          const logStore = new LogStore(
+            getPinoLogger({ name: "framework-node" }),
+            500
+          );
+          logStore.appendLog(["parsing body: ", { body: config.body }]);
 
-      const parsedBody = pipe(
-        either.tryCatch(
-          () => (event.body ? JSON.parse(event.body) : null),
-          () => `event.body not JSON parsable: ${event.body}`
-        ),
-        either.chainW((jsonParsedBody) => parse(config.body, jsonParsedBody)),
-        taskEither.fromEither,
-        taskEither.map((v) => {
-          logStore.appendLog(["parsed body successfully: ", v]);
-          return v;
-        }),
-        taskEither.mapLeft((e) =>
-          string.isString(e) ? e : `Incorrect Body Detail: ${draw(e)}`
-        )
-      );
+          const parsedBody = pipe(
+            either.tryCatch(
+              () => (event.body ? JSON.parse(event.body) : null),
+              () => `event.body not JSON parsable: ${event.body}`
+            ),
+            either.chainW((jsonParsedBody) => parse(config.body, jsonParsedBody)),
+            taskEither.fromEither,
+            taskEither.map((v) => {
+              logStore.appendLog(["parsed body successfully: ", { body: v }]);
+              return v;
+            }),
+            taskEither.mapLeft((e) =>
+              string.isString(e) ? e : `Incorrect Body Detail: ${draw(e)}`
+            )
+          );
 
-      // we build the task making sure to have a readable error if the decoding fails
-      const handlerTask = pipe(
-        taskEither.Do,
-        taskEither.bind("body", () => parsedBody),
-        taskEither.bind("env", () =>
-          config.envSchema
-            ? parseRecordValues(config.envSchema, envRuntime, logStore)
-            : taskEither.of(undefined)
-        ),
-        taskEither.bind("headers", () =>
-          config.headers
-            ? parseRecordValues(config.headers, event.headers, logStore)
-            : taskEither.of(undefined)
-        ),
-        taskEither.chain((i) => handler({ ...i, logStore }))
-      );
+          // we build the task making sure to have a readable error if the decoding fails
+          const handlerTask = pipe(
+            taskEither.Do,
+            taskEither.bind("body", () => parsedBody),
+            taskEither.bind("env", () =>
+              config.envSchema
+                ? parseRecordValues(config.envSchema, envRuntime, logStore)
+                : taskEither.of(undefined)
+            ),
+            taskEither.bind("headers", () =>
+              config.headers
+                ? parseRecordValues(config.headers, event.headers, logStore)
+                : taskEither.of(undefined)
+            ),
+            taskEither.chain((i) => handler({ ...i, logStore }))
+          );
 
-      // we throw in case of error
-      return handlerTask()
-        .then((result) => {
-          if (either.isLeft(result)) {
-            if (string.isString(result.left)) {
-              throw `[node-framework] ${result.left}`;
-            } else {
-              logStore.appendLog(["unknown error...: ", result.left]);
-              throw new Error("[node-framework] handler unknown error");
-            }
-          }
+          // we throw in case of error
+          return handlerTask()
+            .then((result) => {
+              if (either.isLeft(result)) {
+                if (string.isString(result.left)) {
+                  throw `[node-framework] ${result.left}`;
+                } else {
+                  logStore.appendLog(["unknown error...: ", { error: result.left }]);
+                  throw new Error("[node-framework] handler unknown error");
+                }
+              }
 
-          logStore.appendLog(["handler succeded with payload: ", result.right]);
-          logStore.reset();
+              logStore.appendLog(["handler succeded with payload: ", { success: result.right }]);
+              logStore.reset();
 
-          return result.right;
-        })
-        .catch((e) => {
-          logStore.appendLog(["handler failed!: ", e]);
-          logStore.reset();
-          throw e;
+              return result.right;
+            })
+            .catch((e) => {
+              logStore.appendLog(["handler failed!: ", e]);
+              logStore.reset();
+              throw e;
+            });
         });
-    });
-  };
+      };
 
 export const _appSyncLambda =
   <A, R, K extends string = never>(
     wrapperFunc: WrapHandler<AppSyncResolverEvent<A>, R | void>,
     envRuntime = process.env
   ) =>
-  (config: AppSyncLambdaConfig<A, K>) =>
-  (
-    handler: ({
-      args,
-      env,
-    }: {
-      args: A;
-      env: Record<K, string> | undefined;
-      logStore: LogStore;
-    }) => taskEither.TaskEither<unknown, R>
-  ) => {
-    return wrapperFunc((event: AppSyncResolverEvent<A>) => {
-      const logStore = new LogStore(
-        getPinoLogger({ name: "framework-node" }),
-        500
-      );
-      logStore.appendLog(["parsing args: ", config.args]);
+    (config: AppSyncLambdaConfig<A, K>) =>
+      (
+        handler: ({
+          args,
+          env,
+        }: {
+          args: A;
+          env: Record<K, string> | undefined;
+          logStore: LogStore;
+        }) => taskEither.TaskEither<unknown, R>
+      ) => {
+        return wrapperFunc((event: AppSyncResolverEvent<A>) => {
+          const logStore = new LogStore(
+            getPinoLogger({ name: "framework-node" }),
+            500
+          );
+          logStore.appendLog(["parsing args: ", { args: config.args }]);
 
-      const parsedArgs = pipe(
-        parse(config.args, event.arguments),
-        taskEither.fromEither,
-        taskEither.map((v) => {
-          logStore.appendLog(["parsed args successfully: ", v]);
-          return v;
-        }),
-        taskEither.mapLeft((e) =>
-          string.isString(e) ? e : `Incorrect Args: ${draw(e)}`
-        )
-      );
+          const parsedArgs = pipe(
+            parse(config.args, event.arguments),
+            taskEither.fromEither,
+            taskEither.map((v) => {
+              logStore.appendLog(["parsed args successfully: ", { args: v }]);
+              return v;
+            }),
+            taskEither.mapLeft((e) =>
+              string.isString(e) ? e : `Incorrect Args: ${draw(e)}`
+            )
+          );
 
-      // we build the task making sure to have a readable error if the decoding fails
-      const handlerTask = pipe(
-        taskEither.Do,
-        taskEither.bind("args", () => parsedArgs),
-        taskEither.bind("env", () =>
-          config.envSchema
-            ? parseRecordValues(config.envSchema, envRuntime, logStore)
-            : taskEither.of(undefined)
-        ),
-        taskEither.chain((i) => handler({ ...i, logStore }))
-      );
+          // we build the task making sure to have a readable error if the decoding fails
+          const handlerTask = pipe(
+            taskEither.Do,
+            taskEither.bind("args", () => parsedArgs),
+            taskEither.bind("env", () =>
+              config.envSchema
+                ? parseRecordValues(config.envSchema, envRuntime, logStore)
+                : taskEither.of(undefined)
+            ),
+            taskEither.chain((i) => handler({ ...i, logStore }))
+          );
 
-      // we throw in case of error
-      return handlerTask()
-        .then((result) => {
-          if (either.isLeft(result)) {
-            if (string.isString(result.left)) {
-              logStore.appendLog(["handler error: ", result.left]);
-              throw new Error(result.left);
-            } else {
-              logStore.appendLog(["unknown error...: ", result.left]);
-              throw new Error("[node-framework] handler unknown error");
-            }
-          }
+          // we throw in case of error
+          return handlerTask()
+            .then((result) => {
+              if (either.isLeft(result)) {
+                if (string.isString(result.left)) {
+                  logStore.appendLog(["handler error: ", { error: result.left }]);
+                  throw new Error(result.left);
+                } else {
+                  logStore.appendLog(["unknown error...: ", { error: result.left }]);
+                  throw new Error("[node-framework] handler unknown error");
+                }
+              }
 
-          logStore.appendLog(["handler succeded with payload: ", result.right]);
-          logStore.reset();
+              logStore.appendLog(["handler succeded with payload: ", { success: result.right }]);
+              logStore.reset();
 
-          return result.right;
-        })
-        .catch((e) => {
-          logStore.appendLog(["handler failed!: ", e]);
-          logStore.reset();
-          throw e;
+              return result.right;
+            })
+            .catch((e) => {
+              logStore.appendLog(["handler failed!: ", e]);
+              logStore.reset();
+              throw e;
+            });
         });
-    });
-  };
+      };
 
 export const getEventLambda = <O, A, R, K extends string = never>(
   i: EventLambdaConfig<A, K>


### PR DESCRIPTION
Pass arguments to `logger.debug` in the right order to make it work with pino.
There has been added some changes to the handlers to adhere the right format of log.
The logger didn't pass the merging object in the right position so pino wasn't logging it.

@tpetrucciani I added you to keep you updated about fixes