### PR TITLE
feat: add raw body as inputs of http lambda

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ type HttpLambdaConfig<
   H extends string
 > = {
   body: D.Decoder<unknown, A>
+  rawBody?: string
   queryparams?: SchemaRecord<H>
   headers?: SchemaRecord<U>
   envSchema?: SchemaRecord<K>
@@ -179,11 +180,13 @@ export const _httpLambda =
   (
     handler: ({
       body,
+      rawBody,
       queryparams,
       headers,
       env,
     }: {
       body: A
+      rawBody: string
       queryparams: Record<H, string> | undefined
       headers: Record<U, string> | undefined
       env: Record<K, string> | undefined
@@ -217,6 +220,7 @@ export const _httpLambda =
       const handlerTask = pipe(
         taskEither.Do,
         taskEither.bind('body', () => parsedBody),
+        taskEither.bind('rawBody', () => taskEither.of(event.body || '')),
         taskEither.bind('env', () =>
           config.envSchema
             ? parseSchemaRecord<K>(
@@ -384,6 +388,7 @@ export const getHttpLambda = <
   return _httpLambda(Sentry.AWSLambda.wrapHandler)(i) as unknown as (
     f: (i: {
       body: A
+      rawBody?: string
       env: Record<K, string> | undefined
       headers: Record<U, string> | undefined
       queryparams: Record<H, string> | undefined


### PR DESCRIPTION
Add `rawBody` (as string) to the HTTP lambda inputs

### Context
The raw body is used to check header signatures. 

_Note_: I tried at first by stringifying the body after the framework has parsed and validated it, but unfortunately this could alter the properties' position in the string, breaking the signature checking algorithm.